### PR TITLE
Generate name for uploaded artifacts

### DIFF
--- a/.github/workflows/python_build_wheel.yaml
+++ b/.github/workflows/python_build_wheel.yaml
@@ -28,4 +28,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          # Use a generated name, since upload-artifacts cannot upload files as is,
+          # and running jobs in matrix result in a artifact name clash.
+          name: python-wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
+          retention-days: 7


### PR DESCRIPTION
This patch generates names based on run matrix to avoid name clash.