### PR TITLE
Calculate statistics prior to running operation

### DIFF
--- a/include/torch_geopooling/quadpool.h
+++ b/include/torch_geopooling/quadpool.h
@@ -1,3 +1,18 @@
+/// Copyright (C) 2024, Yakau Bubnou
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #pragma once
 
 #include <optional>
@@ -10,6 +25,17 @@
 namespace torch_geopooling {
 
 
+/// Applies linear transformation over Quadtree decomposition of input 2D coordinates.
+///
+/// This function constructs a lookup quadtree to group closely situated 2D points. Each terminal
+/// node in the resulting quadtree is paired with weight and bias. Thus when providing an input
+/// coordinate, the function retrieves the corresponding terminal node for each input coordinate
+/// and returns weight and bias.
+///
+/// This function is stateless, but training could change internal quadtree, therefore it
+/// returns quadtree tiles to reconstruct the learned quadtree on the next evaluation iteration.
+///
+/// \return tuple of tree elements: (tiles, weights, biases).
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 linear_quad_pool2d(
     const torch::Tensor& tiles,
@@ -24,6 +50,15 @@ linear_quad_pool2d(
 );
 
 
+/// Applies maximum pooling over Quadtree decomposition of 2D coordinates.
+///
+/// This module constructs a lookup quadtree to group closely situated 2D points. Each terminal
+/// node in the resulting quadtree is paired with weight. When computing the weight for the
+/// input coordinate, method selects maximum value of weights within a terminal node group.
+///
+/// Terminal node group is a set of nodes in a lookup quadtree that share the common parent.
+///
+/// \return tuple of two elements: (tiles, weights).
 std::tuple<torch::Tensor, torch::Tensor>
 max_quad_pool2d(
     const torch::Tensor& tiles,

--- a/include/torch_geopooling/quadtree_set.h
+++ b/include/torch_geopooling/quadtree_set.h
@@ -231,11 +231,11 @@ public:
     /// and iterates over all terminal nodes of the parent. When node does not belong to a
     /// terminal node, method returns `end()`, or empty iterator.
     ///
-    /// @param point a 2-dimensional point.
-    /// @param max_depth a maximum depth of the look operation. When specified, the point lookup
+    /// \param point a 2-dimensional point.
+    /// \param max_depth a maximum depth of the look operation. When specified, the point lookup
     ///     process is limited by the specified depth.
     ///
-    /// @returns The iterator over a group of terminal nodes.
+    /// \return The iterator over a group of terminal nodes.
     iterator
     find_terminal_group(
         const key_type& point,
@@ -520,10 +520,8 @@ private:
         m_queue.pop();
 
         if (m_set->has_children(tile)) {
-            for (std::size_t x : {0, 1}) {
-                for (std::size_t y : {0, 1}) {
-                    m_queue.push(tile.child(x, y));
-                }
+            for (auto child_tile : tile.children()) {
+                m_queue.push(child_tile);
             }
         }
         return *this;

--- a/include/torch_geopooling/tile.h
+++ b/include/torch_geopooling/tile.h
@@ -1,3 +1,18 @@
+/// Copyright (C) 2024, Yakau Bubnou
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #pragma once
 
 #include <cstdint>
@@ -49,6 +64,8 @@ public:
 
     Tile child(std::size_t x, std::size_t y) const;
 
+    std::vector<Tile> children() const;
+
     template<typename T>
     std::vector<T>
     vec()
@@ -73,6 +90,9 @@ public:
         os << "Tile(" << t.m_z << ", " << t.m_x << ", " << t.m_y << ")";
         return os;
     }
+
+    bool
+    operator<(const Tile& rhs) const;
 
     const static Tile root;
 private:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
             name="torch_geopooling._C",
             sources=[
                 "src/quadpool.cc",
-                "src/quadtree.cc",
                 "src/tile.cc",
                 "torch_geopooling/__bind__/python_module.cc",
             ],

--- a/src/quadtree.cc
+++ b/src/quadtree.cc
@@ -1,8 +1,0 @@
-#include <torch_geopooling/exception.h>
-#include <torch_geopooling/quadtree.h>
-
-
-namespace torch_geopooling {
-
-
-} // namespace torch_geopooling

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -1,3 +1,18 @@
+/// Copyright (C) 2024, Yakau Bubnou
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #include <torch_geopooling/exception.h>
 #include <torch_geopooling/tile.h>
 
@@ -65,6 +80,20 @@ Tile::child(std::size_t x, std::size_t y) const
 }
 
 
+std::vector<Tile>
+Tile::children() const
+{
+    std::vector<Tile> tiles;
+
+    for (std::size_t x : {0, 1}) {
+        for (std::size_t y : {0, 1}) {
+            tiles.push_back(child(x, y));
+        }
+    }
+    return tiles;
+}
+
+
 bool
 Tile::operator==(const Tile& rhs) const
 {
@@ -76,6 +105,19 @@ bool
 Tile::operator!=(const Tile& rhs) const
 {
     return !(*this == rhs);
+}
+
+
+bool
+Tile::operator<(const Tile& rhs) const
+{
+    if (m_z != rhs.m_z) {
+        return m_z < rhs.m_z;
+    }
+    if (m_x != rhs.m_x) {
+        return m_x < rhs.m_x;
+    }
+    return m_y < rhs.m_y;
 }
 
 

--- a/torch_geopooling/nn.py
+++ b/torch_geopooling/nn.py
@@ -60,7 +60,7 @@ class LinearQuadPool2d(_QuadPool):
 
     This module constructs an internal lookup quadtree to organize closely situated 2D points.
     Each terminal node in the resulting quadtree is paired with a weight and bias. Thus, when
-    providing an input coordinate, the module retrieves the corresponding termina node and
+    providing an input coordinate, the module retrieves the corresponding terminal node and
     returns its associated weight and bias. Then module applies a linear transformation to each
     input coordinate.
 


### PR DESCRIPTION
This patch changes computation of statistic-op (like max), so that statistics are initially computed for a tree and only then for input coordinates -> this reduces computational footprint.