### PR TITLE
Rename "conan" to "setuptools_cxx"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ requires = [
 ]
 
 
-[tool.conan]
+[tool.setuptools_cxx]
 remotes = [
   {name = "conancenter", url = "https://center.conan.io", verify_ssl = true}
 ]
@@ -76,7 +76,7 @@ tool_requires = ["cmake/[>=3.20 <4]"]
 generators = ["AutotoolsDeps"]
 requires = ["llvm-openmp/17.0.6", "fmt/10.2.1"]
 
-[tool.conan.settings]
+[tool.setuptools_cxx.settings]
 "compiler.cppstd" = "gnu17"
 
 

--- a/setuptools_cxx/build_ext.py
+++ b/setuptools_cxx/build_ext.py
@@ -104,7 +104,7 @@ class BuildExtBackend:
 
     def initialize_configuration(self, pyproject_text: str) -> None:
         pyproject = tomllib.loads(pyproject_text)
-        self.configuration = pyproject.get("tool", {}).get("conan")
+        self.configuration = pyproject.get("tool", {}).get("setuptools_cxx")
 
     def initialize_conanfile(self) -> None:
         conanfile = ConanFile("torch_geopooling")


### PR DESCRIPTION
This patch renames section in `pyproject.toml`, which corresponds to building c++ extension using conan builder.

Closes #26 