### PR TITLE
Run container action in a separate job

### DIFF
--- a/.github/workflows/python_build_wheel.yaml
+++ b/.github/workflows/python_build_wheel.yaml
@@ -34,6 +34,13 @@ jobs:
           path: wheelhouse/*.whl
           retention-days: 7
 
+  upload_pypi:
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
       - uses: actions/download-artifact@v4.1.8
         with:
           name: python-wheels-${{ matrix.os }}


### PR DESCRIPTION
Run artifact upload to pypi in a separate job (run on ubuntu).