### PR TITLE
Build CPython builds up to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ skip = "*.ipynb"
 # Configuration to build wheels for different version of python, operating systems and
 # architectures. See more in documentation: https://cibuildwheel.pypa.io/en/stable/options/
 [tool.cibuildwheel]
-build = "cp39-*"
+build = "cp39-* cp310-* cp311-* cp312-*"
 build-verbosity = 3
 skip = "*-musllinux_*"
 repair-wheel-command = ""


### PR DESCRIPTION
This patch builds CPython wheels versions up to 3.12.