### PR TITLE
Adaptive pooling optimization

### DIFF
--- a/include/torch_geopooling/tile.h
+++ b/include/torch_geopooling/tile.h
@@ -76,7 +76,7 @@ public:
     std::vector<T>
     vec() const
     {
-        std::vector<T> zxy({static_cast<T>(m_z), static_cast<T>(m_y), static_cast<T>(m_x)});
+        std::vector<T> zxy({static_cast<T>(m_z), static_cast<T>(m_x), static_cast<T>(m_y)});
         return zxy;
     }
 

--- a/test/tile_test.cc
+++ b/test/tile_test.cc
@@ -34,4 +34,15 @@ BOOST_AUTO_TEST_CASE(tile_children)
 }
 
 
+BOOST_AUTO_TEST_CASE(tile_vec)
+{
+    auto tile = Tile(10, 30, 40);
+
+    auto actual = tile.template vec<int64_t>();
+    std::vector<int64_t> expect({10, 30, 40});
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expect.begin(), expect.end());
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/torch_geopooling/functional.py
+++ b/torch_geopooling/functional.py
@@ -271,10 +271,12 @@ class AdaptiveFunction(autograd.Function):
         weight, input = ctx.saved_tensors
         tiles, w = cls.sparse_ravel(weight)
 
-        grad_weight_out = cls.backward_impl(grad_values, tiles, w, input, ctx.exterior, *ctx.params)  # type: ignore
-        grad_weight_out = cls.sparse_unravel(tiles, grad_weight_out, size=weight.size())
+        grad_weight_dense = cls.backward_impl(
+            grad_values, tiles, w, input, ctx.exterior, *ctx.params
+        )  # type: ignore
+        grad_weight_sparse = cls.sparse_unravel(tiles, grad_weight_dense, size=weight.size())
 
-        return grad_weight_out.coalesce(), None, None, None, None
+        return grad_weight_sparse.coalesce(), None, None, None, None
 
     @classmethod
     def func(

--- a/torch_geopooling/functional_test.py
+++ b/torch_geopooling/functional_test.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 
 from torch_geopooling.functional import (
+    AdaptiveFunction,
     adaptive_quad_pool2d,
     adaptive_avg_quad_pool2d,
     adaptive_max_quad_pool2d,
@@ -24,6 +25,20 @@ from torch_geopooling.functional import (
     max_quad_pool2d,
     quad_pool2d,
 )
+
+
+def test_adaptive_function_ravel() -> None:
+    size = (2, 2, 2, 1)
+    tiles = torch.tensor([[0, 0, 0], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]], dtype=torch.int64)
+
+    weight = torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]], dtype=torch.float64)
+
+    sparse = AdaptiveFunction.sparse_unravel(tiles, weight, size=size)
+    torch.testing.assert_close(sparse.to_dense().to_sparse_coo(), sparse)
+
+    tiles_out, weight_out = AdaptiveFunction.sparse_ravel(sparse)
+    torch.testing.assert_close(tiles_out, tiles)
+    torch.testing.assert_close(weight_out, weight)
 
 
 @pytest.mark.parametrize(

--- a/torch_geopooling/nn.py
+++ b/torch_geopooling/nn.py
@@ -91,7 +91,12 @@ class _AdaptiveQuadPool(nn.Module):
     def initialize_parameters(self) -> None:
         # The weight for adaptive operation should be sparse, since training operation
         # results in a dynamic change of the underlying quadtree.
-        weight_size = (self.max_depth, 1 << self.max_depth, 1 << self.max_depth, self.feature_dim)
+        weight_size = (
+            self.max_depth + 1,
+            1 << self.max_depth,
+            1 << self.max_depth,
+            self.feature_dim,
+        )
         self.weight = nn.Parameter(torch.sparse_coo_tensor(size=weight_size, dtype=torch.float64))
 
     @property

--- a/torch_geopooling/nn_test.py
+++ b/torch_geopooling/nn_test.py
@@ -87,8 +87,10 @@ def test_adaptive_quad_pool2d_optimize() -> None:
     weight = pool.weight.to_dense()
 
     for i, tile in enumerate(y_tile):
+        z, x, y = tile
         expect_weight = y_true[i].item()
-        actual_weight = weight[*tile].detach().item()
+        actual_weight = weight[z, x, y].detach().item()
+
         assert pytest.approx(expect_weight, abs=1e-1) == actual_weight, f"tile {tile} is wrong"
 
 


### PR DESCRIPTION
This patch fixes a bug in Tile class: method `vec` was returning `zyx` in stead of `zxy`. Also the patch adds unit tests to ensure that weights modules are trainable.