### PR TITLE
Add an optional wrapping to the embedding

### DIFF
--- a/include/torch_geopooling/embedding.h
+++ b/include/torch_geopooling/embedding.h
@@ -27,7 +27,8 @@ embedding2d(
     const torch::Tensor& input,
     const torch::Tensor& weight,
     const c10::IntArrayRef& padding,
-    const c10::ArrayRef<double>& exterior
+    const c10::ArrayRef<double>& exterior,
+    bool reflection = true
 );
 
 
@@ -37,7 +38,8 @@ embedding2d_backward(
     const torch::Tensor& input,
     const torch::Tensor& weight,
     const c10::IntArrayRef& padding,
-    const c10::ArrayRef<double>& exterior
+    const c10::ArrayRef<double>& exterior,
+    bool reflection = true
 );
 
 

--- a/src/embedding.cc
+++ b/src/embedding.cc
@@ -33,13 +33,15 @@ embedding2d(
     const torch::Tensor& input,
     const torch::Tensor& weight,
     const c10::IntArrayRef& padding,
-    const c10::ArrayRef<double>& exterior
+    const c10::ArrayRef<double>& exterior,
+    bool reflection
 )
 {
     auto options = embedding_options{
         .padding = padding.vec(),
         .exterior = exterior.vec(),
         .manifold = weight.sizes().vec(),
+        .reflection = reflection,
     };
 
     check_shape_forward("embedding2d", input, weight, options);
@@ -91,13 +93,15 @@ embedding2d_backward(
     const torch::Tensor& input,
     const torch::Tensor& weight,
     const c10::IntArrayRef& padding,
-    const c10::ArrayRef<double>& exterior
+    const c10::ArrayRef<double>& exterior,
+    bool reflection
 )
 {
     auto options = embedding_options{
         .padding = padding.vec(),
         .exterior = exterior.vec(),
         .manifold = weight.sizes().vec(),
+        .reflection = reflection,
     };
 
     check_shape_backward("embedding2d_backward", grad, input, weight, options);

--- a/src/embedding_op.h
+++ b/src/embedding_op.h
@@ -34,6 +34,7 @@ struct embedding_options {
     std::vector<int64_t> padding;
     std::vector<double> exterior;
     std::vector<int64_t> manifold;
+    bool reflection;
 
     std::vector<int64_t>
     kernel_size() const
@@ -134,10 +135,15 @@ struct embedding_op {
     }
 
     inline std::tuple<int64_t, int64_t>
-    reflect(double x, double y) const
+    reflect(int64_t x, int64_t y) const
     {
-        x = modulo(x, m_options.manifold[0]);
-        y = modulo(y, m_options.manifold[1]);
+        if (m_options.reflection) {
+            x = modulo(x, m_options.manifold[0]);
+            y = modulo(y, m_options.manifold[1]);
+        } else {
+            x = std::max(std::min(x, m_options.manifold[0] - 1), (int64_t)0);
+            y = std::max(std::min(y, m_options.manifold[1] - 1), (int64_t)0);
+        }
         return std::make_tuple(x, y);
     }
 };

--- a/test/embedding_op_test.cc
+++ b/test/embedding_op_test.cc
@@ -23,6 +23,7 @@ BOOST_AUTO_TEST_CASE(embedding_options_exterior)
         .padding = {0, 0},
         .exterior = {0, 0},
         .manifold = {0, 0},
+        .reflection = true,
     };
 
     auto input = torch::empty({1, 1});
@@ -41,6 +42,7 @@ BOOST_AUTO_TEST_CASE(embedding_options_padding)
         .padding = {0},
         .exterior = {0.0, 0.0, 10.0, 10.0},
         .manifold = {4, 4, 3},
+        .reflection = true,
     };
 
     auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64);
@@ -75,6 +77,7 @@ BOOST_AUTO_TEST_CASE(embedding_check_shape_forward)
         .padding = {0, 0},
         .exterior = {0.0, 0.0, 10.0, 10.0},
         .manifold = {16, 16, 5},
+        .reflection = true,
     };
 
     auto int64_dtype = torch::TensorOptions().dtype(torch::kInt64);
@@ -123,6 +126,7 @@ BOOST_AUTO_TEST_CASE(embedding_check_shape_backward)
         .padding = {4, 2},
         .exterior = {0.0, 0.0, 10.0, 10.0},
         .manifold = {16, 16, 7},
+        .reflection = true,
     };
 
     auto float64_dtype = torch::TensorOptions().dtype(torch::kFloat64);

--- a/test/embedding_test.cc
+++ b/test/embedding_test.cc
@@ -153,4 +153,22 @@ BOOST_AUTO_TEST_CASE(embedding2d_eval_large)
 }
 
 
+BOOST_AUTO_TEST_CASE(embedding2d_no_reflection)
+{
+    auto options = torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCPU);
+
+    auto weight = torch::rand({1024, 1024, 4}, options);
+    auto input = torch::rand({100, 2}, options) * 12.0;
+
+    auto output = embedding2d(
+        input, weight,
+        /*padding=*/{10, 10},
+        /*exterior=*/{-10.0, 10.0, 20.0, 20.0},
+        /*reflection=*/false
+    );
+
+    BOOST_CHECK_EQUAL(output.sizes(), c10::IntArrayRef({100, 21, 21, 4}));
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/torch_geopooling/__init__.py
+++ b/torch_geopooling/__init__.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-__version__: Final[str] = "1.1.1"
+__version__: Final[str] = "1.1.2"

--- a/torch_geopooling/functional/embedding_test.py
+++ b/torch_geopooling/functional/embedding_test.py
@@ -26,6 +26,7 @@ def test_embedding2d() -> None:
         weight,
         padding=(3, 2),
         exterior=(-10.0, -10.0, 20.0, 20.0),
+        reflection=True,
     )
 
     assert result.size() == torch.Size([100, 7, 5, 3])

--- a/torch_geopooling/nn/embedding.py
+++ b/torch_geopooling/nn/embedding.py
@@ -46,6 +46,8 @@ class Embedding2d(nn.Module):
         exterior: The geometric boundary of the learning space, specified as a tuple (X, Y, W, H),
             where X and Y represent the origin, and W and H represent the width and height of the
             space, respectively.
+        reflection: When true, kernel is wrapped around the exterior space, otherwise kernel is
+            squeezed into borders.
 
     Shape:
         - Input: :math:`(*, 2)`, where 2 comprises x and y coordinates.
@@ -74,17 +76,27 @@ class Embedding2d(nn.Module):
         manifold: Tuple[int, int, int],
         exterior: _Exterior,
         padding: Tuple[int, int] = (0, 0),
+        reflection: bool = True,
     ) -> None:
         super().__init__()
         self.manifold = manifold
         self.exterior = cast(ExteriorTuple, tuple(map(float, exterior)))
         self.padding = padding
+        self.reflection = reflection
 
         self.weight = nn.Parameter(torch.empty(manifold, dtype=torch.float64))
         nn.init.zeros_(self.weight)
 
     def extra_repr(self) -> str:
-        return "{manifold}, exterior={exterior}, padding={padding}".format(**self.__dict__)
+        return "{manifold}, exterior={exterior}, padding={padding}, reflection={reflection}".format(
+            **self.__dict__
+        )
 
     def forward(self, input: Tensor) -> Tensor:
-        return F.embedding2d(input, self.weight, exterior=self.exterior, padding=self.padding)
+        return F.embedding2d(
+            input,
+            self.weight,
+            exterior=self.exterior,
+            padding=self.padding,
+            reflection=self.reflection,
+        )


### PR DESCRIPTION
This patch adds optional parameter `reflecting` to control kernel wrapping around the exterior.