### PR TITLE
Add funding link to the PyPI meta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Torch CONFIG REQUIRED)
 enable_testing()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
-set(torch_geopooling_LIBRARY_VERSION "1.1.2")
+set(torch_geopooling_LIBRARY_VERSION "1.1.3")
 set(torch_geopooling_LIBRARY_SOVERSION "1")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ dependencies = ["shapely>=2.0.0", "torch >= 2.3.0, < 2.4.0"]
 
 
 [project.urls]
-homepage = "https://github.com/ybubnov/torch_geopooling"
-source = "https://github.com/ybubnov/torch_geopooling"
+Funding = "https://github.com/sponsors/ybubnov"
+Homepage = "https://github.com/ybubnov/torch_geopooling"
+Source = "https://github.com/ybubnov/torch_geopooling"
 
 
 [project.optional-dependencies]

--- a/torch_geopooling/__init__.py
+++ b/torch_geopooling/__init__.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-__version__: Final[str] = "1.1.2"
+__version__: Final[str] = "1.1.3"


### PR DESCRIPTION
This patch adds a funding link to the PyPI metainformation and also bumps the package version to 1.1.3.